### PR TITLE
refactor: remove nonstandard symbols and fix common/dummy conflict

### DIFF
--- a/Source_VSOP-ZUT/zdata2.f
+++ b/Source_VSOP-ZUT/zdata2.f
@@ -33,7 +33,7 @@ C                                                                       ZDA  310
 C                                                                       ZDA  330
       RETURN                                                            ZDA  340
       END                                                               ZDA  350
-      SUBROUTINE SUBMAI(NGAM,NTHER,NZUT,NDANC,KOSTDA,IU4,IMAT)          SUB   10
+      SUBROUTINE SUBMAI(NGAM,NTHER,NZUT,NDANC,KOSTIN,IU4,IMAT)          SUB   10
 C                                                                       SUB   20
       COMMON /VARIAD/ KMAT,IACT                                         SUB   30
 C                                                                       SUB   40
@@ -69,6 +69,7 @@ C                                                                       SUB  310
 C                                                                       SUB  340
 C                                                                       SUB  350
       IU8T = 0                                                          SUB  360
+      KOSTDA = KOSTIN                                                   SUB  365
       KOSTD2 = KOSTDA                                                   SUB  370
       FF2 = 0.61                                                        SUB  380
       N3 = 3                                                            SUB  390
@@ -242,7 +243,8 @@ C                                                                       SUB 1210
      2 I=1,NISO)                                                        SUB 2070
       NXT29 = NXT29 + 1                                                 SUB 2080
       GOTO 7999                                                         SUB 2090
- 8000 RETURN                                                            SUB 2100
+ 8000 KOSTIN = KOSTDA                                                   SUB 2095
+      RETURN                                                            SUB 2100
 C                                                                       SUB 2110
  1000 FORMAT (18A4)                                                     SUB 2120
  1001 FORMAT (6E12.5)                                                   SUB 2130

--- a/Source_VSOP-ZUT/zut1.f
+++ b/Source_VSOP-ZUT/zut1.f
@@ -14,6 +14,8 @@ C                                                                       UT    50
      7 ENULL(500),CORINT(500),LOESCH(9),NFT(30),NRMAF(40),DEN(40),      UT   130
      8 IMA(40)                                                          UT   140
       CHARACTER*3 FLAG(16),HEAD(24),REASON(32),TFLAG(16),UNIT(2)        UT   150
+C                                                                       UT   155
+      INTEGER IPTMP,JPTMP,KFAOP                                        UT   156
 C                                                                       UT   160
       COMMON /GAGRU/ EGO(69),SIRA(69),FF,FL,M6,NGGR,NGGR1,EOE,EERSTE,   UT   170
      1 ELETZT,IO,IU,RIJS,MMEES,IIII,JRJR,ITUZ,IGRUG,M5,NEUI,NALTI,      UT   180
@@ -60,9 +62,9 @@ C                                                                       UT   570
 C                                                                       UT   590
       CHARACTER*3 FCP017,FCP018,FCP019,FCP020,FCP021,FCP022,FCP023,     UT   600
      1 FCP024,FCP025,FCP026,FCP028,FCP029                               UT   610
-      DATA FCP017/'10',FCP018/'11',FCP019/' ZU',FCP020/'T C',           UT   620
-     1 FCP021/'ROS',FCP022/'S S',FCP023/'ECT',FCP024/'ION',             UT   630
-     2 FCP025/'D-S',FCP026/'ET ',FCP028/'END',FCP029/'REP'              UT   640
+      PARAMETER (FCP017='10',FCP018='11',FCP019=' ZU',FCP020='T C',     UT   620
+     1 FCP021='ROS',FCP022='S S',FCP023='ECT',FCP024='ION',             UT   630
+     2 FCP025='D-S',FCP026='ET ',FCP028='END',FCP029='REP')            UT   640
 C                                                                       UT   630
   400 FORMAT (A8)                                                       UT   640
   411 FORMAT (/////' ***** "MODE" (Card ZS) OUT OF RANGE *****'//' *****UT   650
@@ -104,7 +106,7 @@ C                                                                       UT   960
 C                                                                       UT  1010
       IF(MODE .EQ. MODE1) CALL ZDATA2                                   UT  1020
 C                                                                       UT  1030
-      CALL PAGE(IP$,JP$,9999)                                           UT  1040
+      CALL PAGE(IPTMP,JPTMP,9999)                                       UT  1040
 C                                                                       UT  1050
     1 CALL COVZUT                                                       UT  1060
 C                                                                       UT  1070
@@ -539,7 +541,7 @@ C     U(IJK) = 0.                                                       UT  5350
 C     IF(IJK-21128) 602,603,603                                         UT  5360
   603 CONTINUE                                                          UT  5370
 C                                                                       UT  5380
-      CALL PAGE(IP$,JP$,9999)                                           UT  5390
+      CALL PAGE(IPTMP,JPTMP,9999)                                       UT  5390
 C                                                                       UT  5400
       IF(IWOHIN .EQ. 9) GOTO 1                                          UT  5410
       GOTO 999                                                          UT  5420
@@ -1288,7 +1290,7 @@ C     ERSTE COMMON- UND DIMENSIONKARTE NUR ZUR SPEICHERLOESCHUNG        RES  430
 C     BEI MEHREREN FAELLEN HINTEREINANDER                               RES  440
 C                                                                       RES  450
 C                                                                       RES  460
-      KFAOP$ = 6                                                        RES  470
+      KFAOP = 6                                                         RES  470
       L = K                                                             RES  480
       DO 2120 IR=L,NAIN                                                 RES  490
         K = IR                                                          RES  500

--- a/Source_VSOP-ZUT/zut2.f
+++ b/Source_VSOP-ZUT/zut2.f
@@ -4,7 +4,7 @@ C                                                                       NUM   20
 C                                                                       NUM   40
       DIMENSION D(12),V(6),Y(5),X(6),IK(4)                              NUM   50
 C                                                                       NUM   60
-      DATA KFAOP$/6/                                                    NUM   70
+      DATA KFAOP/6/                                                     NUM   70
 C                                                                       NUM   80
 C                                                                       NUM   90
 C     NUMERISCHE INTEGRATION                                            NUM  100
@@ -72,7 +72,7 @@ C                                                                       NUM  400
       IF(IK(4)-600) 1,1,11                                              NUM  720
    10 CNUMI = FSIMP                                                     NUM  730
       RETURN                                                            NUM  740
-   11 WRITE (KFAOP$,12)                                                 NUM  750
+   11 WRITE (KFAOP,12)                                                  NUM  750
 C                                                                       NUM  760
    12 FORMAT (' BEYOND 600 SIMP-INTEGR-ITERATIONS FOR ONE INTEGRAL')    NUM  770
       RETURN                                                            NUM  780
@@ -263,7 +263,7 @@ C                                                                       OPP   60
 C                                                                       OPP   90
       DIMENSION SR(10),RRO2(10),CA(10),D(12),EW(20)                     OPP  100
 C                                                                       OPP  110
-      DATA KFAOP$/6/                                                    OPP  120
+      DATA KFAOP/6/                                                     OPP  120
 C                                                                       OPP  130
       CHARACTER*4 A(26)/'SING','LE  ','DOUB','LE  ','BED ','OF P','EBBL'OPP  140
      1,'ES  ','LATT','ICE ','OF R','ODS ','ABSO','RBER','PART','ICLS',  OPP  150
@@ -400,7 +400,7 @@ C                                                                       OPP 1320
       GOTO 16                                                           OPP 1460
   321 CONTINUE                                                          OPP 1470
       ELR = 2. / (3.*F)                                                 OPP 1480
-      IF(ELR .LT. 1.) WRITE (KFAOP$,320)                                OPP 1490
+      IF(ELR .LT. 1.) WRITE (KFAOP,320)                                 OPP 1490
       ZE2 =  DEXP(-SR(2)*ELR)                                           OPP 1500
       IF(ELR .LT. (2.*R2/R1)) GOTO 324                                  OPP 1510
       ZE1 = ZE2                                                         OPP 1520
@@ -440,9 +440,9 @@ C                                                                       OPP 1670
       I6 = I5 + 3                                                       OPP 1860
       I8 = I7 + 5 * IFF                                                 OPP 1870
       IF(ALPH .GT. 0.) I8 = I7 + 5                                      OPP 1880
-      WRITE (KFAOP$,100) (A(I),I=I1,I2),(A(I),I=I3,I4)                  OPP 1890
-      IF(R2 .NE. 0.) WRITE (KFAOP$,101) (A(I),I=I5,I6),(A(I),I=I7,I8)   OPP 1900
-      WRITE (KFAOP$,102) R1,R2,R4,R5,SI2,SI4,SI5,F,H                    OPP 1910
+      WRITE (KFAOP,100) (A(I),I=I1,I2),(A(I),I=I3,I4)                   OPP 1890
+      IF(R2 .NE. 0.) WRITE (KFAOP,101) (A(I),I=I5,I6),(A(I),I=I7,I8)    OPP 1900
+      WRITE (KFAOP,102) R1,R2,R4,R5,SI2,SI4,SI5,F,H                     OPP 1910
   110 CONTINUE                                                          OPP 1920
 C                                                                       OPP 1930
 C     DIE ANDEREN A                                                     OPP 1940
@@ -532,7 +532,7 @@ C                                                                       OPP 2610
       IF(IFALL .EQ. 1) GOTO 30                                          OPP 2780
       IF((EW(7)-DFLOAT(IFIX(SNGL(EW(7)))/10)*10.)- 1.) 31,30,30         OPP 2790
    30 CONTINUE                                                          OPP 2800
-      WRITE (KFAOP$,103) IFALL,SNU,SIGA,SI1,SI3                         OPP 2810
+      WRITE (KFAOP,103) IFALL,SNU,SIGA,SI1,SI3                          OPP 2810
       IF(R2 .EQ. 0.) GOTO 84                                            OPP 2820
       IF(IFF .EQ. 0) GOTO 325                                           OPP 2830
       SI31S = SI1 * F                                                   OPP 2840
@@ -549,9 +549,9 @@ C                                                                       OPP 2610
       QSIG3S = SI32S / SI3S                                             OPP 2950
       SMIK2E = SI32S / DNEINF                                           OPP 2960
       IF(IFALL .GT. 1) GOTO 84                                          OPP 2970
-      WRITE (KFAOP$,57) DNEINF,SMIK2E                                   OPP 2980
+      WRITE (KFAOP,57) DNEINF,SMIK2E                                    OPP 2980
    84 CONTINUE                                                          OPP 2990
-      WRITE (KFAOP$,98) P,P1                                            OPP 3000
+      WRITE (KFAOP,98) P,P1                                             OPP 3000
       IF(R2 .NE. 0.) GOTO 85                                            OPP 3010
       IF(R5 .GT. 0.) GOTO 305                                           OPP 3020
       A1 = 0.                                                           OPP 3030
@@ -565,14 +565,14 @@ C                                                                       OPP 2610
       IF(SIGA-10000.) 41,40,40                                          OPP 3110
    40 CDANK = 1. - P / (A1+A2)                                          OPP 3120
       IF(R5 .GT. 0.) EW(14) = 1. - (A4+A5*A7/A9) / (A4+A5)              OPP 3130
-      WRITE (KFAOP$,97) CDANK                                           OPP 3140
-      WRITE (KFAOP$,197) EW(14)                                         OPP 3150
+      WRITE (KFAOP,97) CDANK                                            OPP 3140
+      WRITE (KFAOP,197) EW(14)                                          OPP 3150
    41 CONTINUE                                                          OPP 3160
    31 CONTINUE                                                          OPP 3170
       IF((EW(7)-DFLOAT(IFIX(SNGL(EW(7)))/100)*100.)-10.) 17,202,202     OPP 3180
   202 CONTINUE                                                          OPP 3190
-      WRITE (KFAOP$,TESTGR)                                             OPP 3200
-      IF(R5 .LE. 0.) WRITE (KFAOP$,310) A1,A2,QSIG3,W5,W8,EW(14)        OPP 3210
+      WRITE (KFAOP,TESTGR)                                              OPP 3200
+      IF(R5 .LE. 0.) WRITE (KFAOP,310) A1,A2,QSIG3,W5,W8,EW(14)         OPP 3210
    17 CONTINUE                                                          OPP 3220
       RETURN                                                            OPP 3230
       END                                                               OPP 3240


### PR DESCRIPTION
## Summary
- replace `$`-suffixed variables with standard names and declare them
- convert character constants to PARAMETERS
- separate `KOSTDA` dummy argument from `/COSTS/` common block

## Testing
- ⚠️ `gfortran Source_VSOP-ZUT/zut1.f Source_VSOP-ZUT/zut2.f Source_VSOP-ZUT/zdata2.f Source_VSOP-ZUT/inplist.f -o /tmp/zut_program` *(gfortran not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a050b517248322815d3a4069b37e78