### PR TITLE
Fix missing parentheses in zut1

### DIFF
--- a/Source_VSOP-ZUT/zut1.f
+++ b/Source_VSOP-ZUT/zut1.f
@@ -430,8 +430,8 @@ C     READ DATE, NOXT LABEL, NNXT LABEL, AND COMMENT                    UT  4240
 C                                                                       UT  4250
       READ (NINP,500,END=501) (HEAD(I),I=1,24)                          UT  4260
 C                                                                       UT  4270
-      IF(HEAD(1) .EQ. FCP028 GOTO 501                                  UT  4280
-      IF(HEAD(1) .EQ. FCP029 GOTO 1                                    UT  4290
+        IF(HEAD(1) .EQ. FCP028) GOTO 501                                  UT  4280
+        IF(HEAD(1) .EQ. FCP029) GOTO 1                                    UT  4290
       IF(IDEN(2)) 30,30,40                                              UT  4300
    30 CONTINUE                                                          UT  4310
 C                                                                       UT  4320


### PR DESCRIPTION
## Summary
- Correct the conditional branching checks for FCP028 and FCP029 in `zut1.f` by adding missing closing parentheses.

## Testing
- ⚠️ `gfortran -c zut1.f` (gfortran not installed; attempted `apt-get update` and `apt-get install -y gfortran` but repository access returned 403 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a072de4ed8832287796ece97edbe73